### PR TITLE
Refactor settings and custom words storage behavior

### DIFF
--- a/src/components/DataSource.js
+++ b/src/components/DataSource.js
@@ -4,19 +4,7 @@ import { PLACEHOLDER_TEXT } from '../data';
 import { DataSources } from '../constants';
 
 function DataSource(props) {
-  const { words, apiKey, setApiKey, settings, setCustomWords, customWords, dataSource, setDataSource } = props;
-
-  const value = useMemo(() => {
-    if (customWords !== null) {
-      return customWords;
-    }
-
-    if (settings.isCustomWords) {
-      return JSON.stringify(words, null, 2);
-    }
-
-    return undefined;
-  }, [customWords]);
+  const { apiKey, setApiKey, setCustomWords, customWords, dataSource, setDataSource } = props;
 
   return (
     <>
@@ -56,7 +44,7 @@ function DataSource(props) {
               onChange={(evt) => setCustomWords(evt.target.value)}
               placeholder={PLACEHOLDER_TEXT}
               style={{ height: '50vh', width: '80%' }}
-              value={value}
+              value={customWords}
             />
           ) : (
             <input

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -36,13 +36,13 @@ function Home() {
       return;
     }
 
-    setSettings({ dataSource, isCustomWords: !!customWords });
+    const parsedCustomWords = parseCustomWords(customWords, shouldShowMeaning);
+    setWords(parsedCustomWords);
   };
 
   const updateApiSettings = () => {
     if (!apiKey) {
       const message = 'API key is required for RapidAPI data source.';
-      console.error(message);
 
       throw new Error(message);
     }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -77,4 +77,41 @@ function Home() {
   );
 }
 
+/**
+ * Parses and validates the passed custom words and throws appropriate errors.
+ *
+ * @param {string} customWords
+ * @param {boolean} shouldShowMeaning
+ * @returns {object}
+ */
+function parseCustomWords(customWords, shouldShowMeaning) {
+  let parsedCustomWords;
+
+  try {
+    parsedCustomWords = JSON.parse(customWords);
+  } catch (e) {
+    throw new Error('Passed data must be a valid JSON Array. Could not parse passed list.');
+  }
+
+  if (!Array.isArray(parsedCustomWords)) {
+    throw new Error('Custom words needs to be an array.');
+  }
+
+  for (let { word, meaning } of parsedCustomWords) {
+    if (!word) {
+      throw new Error(
+        `Every element in passed data must have a "word" ${shouldShowMeaning ? 'as well as a "meaning"' : ''} property.`
+      );
+    }
+
+    if (shouldShowMeaning && !meaning) {
+      throw new Error(
+        `Every element in passed data must have a "meaning" property. Turn off "Display meaning of current word" setting to continue without "meaning" property.`
+      );
+    }
+  }
+
+  return parsedCustomWords;
+}
+
 export default Home;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -12,22 +12,12 @@ function Home() {
   const [words, setWords, resetWords] = useWordsState();
   const [settings, setSettings] = useSettingsState();
 
-  const [customWords, setCustomWords] = useState(null);
-  const [apiKey, setApiKey] = useState(settings.apiKey);
-  const [dataSource, setDataSource] = useState(settings.dataSource);
+  const { apiKey: apiKeySetting, dataSource: dataSourceSetting, shouldShowMeaning } = settings;
 
-  const updateCustomStaticData = () => {
-    if (customWords !== null) {
-      let parsedCustomWords;
-
-      try {
-        parsedCustomWords = JSON.parse(customWords || JSON.stringify(DEFAULT_WORDS));
-      } catch (e) {
-        const message = 'Passed data must be a valid JSON Array. Could not parse passed list.';
-        console.error(message, e);
-
-        throw new Error(message);
-      }
+  const defaultCustomWords = (words && JSON.stringify(words, null, 2)) || '';
+  const [customWords, setCustomWords] = useState(defaultCustomWords);
+  const [apiKey, setApiKey] = useState(apiKeySetting);
+  const [dataSource, setDataSource] = useState(dataSourceSetting);
 
   const updateCustomStaticData = () => {
     if (!customWords) {
@@ -54,6 +44,7 @@ function Home() {
     try {
       if (dataSource === DataSources.STATIC) {
         updateCustomStaticData();
+        setSettings({ dataSource });
       }
 
       if (dataSource === DataSources.API) {
@@ -62,6 +53,7 @@ function Home() {
 
       history.push('/selector');
     } catch (e) {
+      console.error(e);
       alert(e.message);
     }
   };

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -3,14 +3,13 @@ import { useHistory } from 'react-router';
 
 import Settings from './Settings';
 import DataSource from './DataSource';
-import { DEFAULT_WORDS } from '../data';
 import { DataSources } from '../constants';
 import { useWordsState } from '../contexts/words';
 import { useSettingsState } from '../contexts/settings';
 
 function Home() {
   const history = useHistory();
-  const [words, setWords] = useWordsState();
+  const [words, setWords, resetWords] = useWordsState();
   const [settings, setSettings] = useSettingsState();
 
   const [customWords, setCustomWords] = useState(null);
@@ -30,15 +29,11 @@ function Home() {
         throw new Error(message);
       }
 
-      if (!Array.isArray(parsedCustomWords)) {
-        throw new Error('Custom words needs to be an array.');
-      }
+  const updateCustomStaticData = () => {
+    if (!customWords) {
+      resetWords();
 
-      if (parsedCustomWords.some(({ word }) => !word)) {
-        throw new Error('Every element in passed data must have a `word` property.');
-      }
-
-      setWords(parsedCustomWords);
+      return;
     }
 
     setSettings({ dataSource, isCustomWords: !!customWords });

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -11,7 +11,7 @@ function Settings({ settings, setSettings }) {
           onChange={(e) => setSettings({ shouldShowMeaning: e.target.checked })}
           checked={settings.shouldShowMeaning}
         />
-        <label htmlFor="display-meaning-setting">Display Meaning of current word</label>
+        <label htmlFor="display-meaning-setting">Display the meaning of current word</label>
       </div>
       <br />
     </>

--- a/src/components/WordSelector.js
+++ b/src/components/WordSelector.js
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 
+import { DEFAULT_WORDS } from '../data';
 import { DataSources } from '../constants';
 import { useWordsState } from '../contexts/words';
 import { getRandomElement } from '../utils/common';
@@ -7,11 +8,13 @@ import { fetchRandomWord } from '../services/wordsApi';
 import { useSettingsState } from '../contexts/settings';
 
 function WordSelector() {
-  const [words] = useWordsState();
+  const [contextWords] = useWordsState();
   const [settings] = useSettingsState();
   const [selectedWords, setSelectedWords] = useState([]);
 
   const { dataSource, apiKey, shouldShowMeaning } = settings;
+
+  const words = contextWords || DEFAULT_WORDS;
 
   const [selectedList, lastSelectedWord, isListExhausted] = useMemo(() => {
     return [

--- a/src/contexts/settings.js
+++ b/src/contexts/settings.js
@@ -17,7 +17,6 @@ import { getObjFromLocalStorage, setObjInLocalStorage } from '../utils/localStor
 
 const LOCAL_STORAGE_SETTING_KEY = 'storedSetting';
 const DEFAULT_SETTINGS = {
-  isCustomWords: false,
   shouldShowMeaning: true,
   apiSourceKey: null,
   dataSource: DataSources.STATIC

--- a/src/contexts/words.js
+++ b/src/contexts/words.js
@@ -12,12 +12,11 @@
 
 import React, { useState, useContext, createContext } from 'react';
 
-import { DEFAULT_WORDS } from '../data';
-import { getObjFromLocalStorage, setObjInLocalStorage } from '../utils/localStorage';
+import { getObjFromLocalStorage, removeObjFromLocalStorage, setObjInLocalStorage } from '../utils/localStorage';
 
 const LOCAL_STORAGE_WORDS_KEY = 'storedWords';
 
-const storedWords = getObjFromLocalStorage(LOCAL_STORAGE_WORDS_KEY, DEFAULT_WORDS);
+const storedWords = getObjFromLocalStorage(LOCAL_STORAGE_WORDS_KEY);
 
 const WordsStateContext = createContext([storedWords, () => null]);
 

--- a/src/contexts/words.js
+++ b/src/contexts/words.js
@@ -18,7 +18,7 @@ const LOCAL_STORAGE_WORDS_KEY = 'storedWords';
 
 const storedWords = getObjFromLocalStorage(LOCAL_STORAGE_WORDS_KEY);
 
-const WordsStateContext = createContext([storedWords, () => null]);
+const WordsStateContext = createContext([storedWords, () => null, () => null]);
 
 function WordsProvider(props) {
   const [defaultWords] = useContext(WordsStateContext);
@@ -26,11 +26,22 @@ function WordsProvider(props) {
   const [words, setWords] = useState(defaultWords);
 
   const updateWords = (words) => {
+    if (!words) {
+      return;
+    }
+
     setWords(words);
     setObjInLocalStorage(LOCAL_STORAGE_WORDS_KEY, words);
   };
 
-  return <WordsStateContext.Provider value={[words, updateWords]}>{props.children}</WordsStateContext.Provider>;
+  const resetWords = () => {
+    setWords(defaultWords);
+    removeObjFromLocalStorage(LOCAL_STORAGE_WORDS_KEY);
+  };
+
+  return (
+    <WordsStateContext.Provider value={[words, updateWords, resetWords]}>{props.children}</WordsStateContext.Provider>
+  );
 }
 
 function useWordsState() {

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -25,3 +25,13 @@ export function setObjInLocalStorage(key, value) {
 
   return localStorage.setItem(key, JSON.stringify(value));
 }
+
+export function removeObjFromLocalStorage(key) {
+  if (!localStorage) {
+    console.warn('No localStorage found!');
+
+    return;
+  }
+
+  return localStorage.removeItem(key);
+}

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -7,7 +7,7 @@ export function getObjFromLocalStorage(key, defaultValue) {
 
   const storedValue = localStorage.getItem(key);
 
-  if (!storedValue) {
+  if (!storedValue && defaultValue) {
     setObjInLocalStorage(key, defaultValue);
 
     return defaultValue;


### PR DESCRIPTION
## Changes

* Update message for display meaning setting
* Check default value before storing it in localStorage
* Add util to remove obj from localStorage
* Stop setting default words in store
This is to change the storage behavior to only store words to localStorage if custom words are chosen.
This is mainly done to remove the 'isCustomWords' setting variable.
* Update WordsStateContext to pass resetWords handler
Also do not update words if the passed words is falsy in updateWords handler.
* Remove isCustomWords from default setting constant
* Fallback to DEFAULT_WORDS if words in context is empty
* Simply display the custom words in DataSource
Remove logic to compute which data to show based on isCustomWords flag
* Reset stored/context words if customWords is empty
* Create separate parseCustomWords service with parsing and validation logic
* Use parseCustomWords service instead of internal logic
* Update default states in Home component
Custom words is set directly based on the value received from words context.
Other states use destructured settings variables.